### PR TITLE
Initial plugin logic

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -1,0 +1,27 @@
+env:
+  PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
+  BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
+
+steps:
+
+  - label: ":lint-roller::bash: Lint Shell"
+    command:
+      - make lint-shell
+    # plugins:
+    #   - grapl-security/vault-login#v0.1.0
+    #   - grapl-security/vault-env#v0.1.0:
+    #       secrets:
+    #         - grapl-release-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+
+  - label: ":lint-roller::buildkite: Lint Plugin"
+    command:
+      - make lint-plugin
+
+  - label: ":bash: Unit Test Shell"
+    command:
+      - make test-shell
+    # plugins:
+    #   - grapl-security/vault-login#v0.1.0
+    #   - grapl-security/vault-env#v0.1.0:
+    #       secrets:
+    #         - grapl-release-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.pids
+/.pants.d

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+COMPOSE_USER=$(shell id -u):$(shell id -g)
+
+RUN_CHECK := docker-compose run --rm --user=${COMPOSE_USER}
+
+.DEFAULT_GOAL=all
+
+# Formatting
+########################################################################
+
+.PHONY: format
+format: format-shell
+
+.PHONY: format-shell
+format-shell:
+	./pants fmt ::
+
+# Linting
+########################################################################
+
+.PHONY: lint
+lint: lint-shell lint-plugin
+
+.PHONY: lint-shell
+lint-shell:
+	./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants lint
+
+.PHONY: lint-plugin
+lint-plugin:
+	${RUN_CHECK} plugin-linter
+
+# Testing
+########################################################################
+.PHONY: test
+test: test-shell
+
+.PHONY: test-shell
+test-shell:
+	./pants test ::
+
+########################################################################
+
+.PHONY: all
+all: format lint test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-# grapl-release-buildkite-plugin
-A Buildkite plugin for managing Grapl releases
+# Grapl Release Buildkite Plugin
+
+Consolidates logic around release creation and tagging for Grapl's pipelines.
+
+This is explicitly tailored for Grapl's needs, and is not intended for
+general usage.
+
+## "Library" Plugin
+
+This plugin is currently structured as a ["library
+plugin"](https://github.com/buildkite-plugins/library-example-buildkite-plugin). It
+provides scripts that are added to the `$PATH` via an `environment`
+hook; these scripts can then be used in the job command.
+
+There is no configuration for this plugin; just add it to your
+`plugins` list (generally toward the top of that list).
+
+## Usecases
+
+### Record Successful Pipeline Runs
+
+At the end of pipelines, we often record the success by resetting a
+lightweight tag; here is how to do that:
+
+```yaml
+steps:
+  - label: ":writing_hand: Record successful build"
+    command:
+      - record_successsful_pipeline_run.sh
+    plugins:
+      - grapl-security/grapl-release#v0.1.0
+```
+
+### Diff-based Logic
+
+Often in our `merge` pipelines, we will use the
+[chronotc/monorepo-diff](https://github.com/chronotc/monorepo-diff-buildkite-plugin)
+plugin to help trigger artifact creation based on whether code has
+changed since the last successful `merge` pipeline run. This logic is
+based on the aforementioned lightweight tags.
+
+To make this custom diff logic easily available, we use the current
+plugin to add the script to the `$PATH`; here is an example of how to
+use it:
+
+```yaml
+steps:
+  - label: ":thinking_face: Build containers?"
+    plugins:
+      - grapl-security/grapl-release#v0.1.0 # <-- Must come first!
+      - chronotc/monorepo-diff#v2.0.4:
+          diff: grapl_diff.sh # <-- Comes from this plugin
+          watch:
+            - path:
+                - file1.txt
+                - file2.txt
+              config:
+                label: ":pipeline: Upload pipeline"
+                command: "buildkite-agent pipeline upload .buildkite/complicated_pipeline.yml"
+```

--- a/bin/grapl_diff.sh
+++ b/bin/grapl_diff.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# A diffing script for use with the chronotc/monorepo-diff Buildkite
+# plugin, and aware of Grapl release pipeline conventions for verify
+# and merge pipelines.
+#
+# In particular, this will modify the diff command appropriately for
+# whether it is running in the context of a verify pipeline, or from
+# the steps of a verify pipeline being run within a merge pipeline.
+#
+# The script will output the names of files changed. DO NOT echo
+# anything else to standard output (e.g., logging statements), or it
+# will be considered as a file that changed.
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/record.sh"
+
+pipeline="$(pipeline_from_env)"
+readonly pipeline
+
+case "${pipeline}" in
+    merge)
+        # If the last run of the merge pipeline failed, we still want
+        # to perform the expensive operations we're using this script
+        # to be selective about.
+        #
+        # For instance, the failing run may have been building Packer
+        # AMI images, but failed due to an unrelated issue in the
+        # build scripts, or something totally unrelated to the Packer
+        # source files. The fix would then not touch those source
+        # files, and we would never rebuild the image.
+        git diff --name-only "$(tag_for_pipeline "${pipeline}")"
+        ;;
+    verify)
+        # We're on a PR branch, so what changed on this branch
+        # relative to main?
+        #
+        # > For example, origin.. is a shorthand for origin..HEAD and asks
+        #   "What did I do since I forked from the origin branch?"
+        #
+        #   - from `man 7 gitrevisions`, "SPECIFYING RANGES"
+        git diff --name-only main..
+        ;;
+    *)
+        # We don't have any other pipelines at the moment, but we'd
+        # like to fail once we do, to ensure we fix this script as
+        # appropriate.
+        exit 42
+        ;;
+esac

--- a/bin/record_successful_pipeline_run.sh
+++ b/bin/record_successful_pipeline_run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# At the end of a successful run of the pipeline, we'll want to
+# record the git SHA of the code we were running.
+#
+# This is to ensure that we can make the appropriate decision whether
+# or not to rebuild artifacts following a *failure* of this pipeline
+# for whatever reason; see the `grapl_diff.sh` script for additional
+# details.
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/record.sh"
+
+tag_last_success "$(pipeline_from_env)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+x-common-variables:
+  read-only-workdir: &read-only-workdir
+    type: bind
+    source: .
+    target: /workdir
+    read_only: true
+  read-write-workdir: &read-write-workdir
+    type: bind
+    source: .
+    target: /workdir
+    read_only: false
+  read-only-plugin: &read-only-plugin
+    # Buildkite containers assume you mount into /plugin
+    type: bind
+    source: .
+    target: /plugin
+    read_only: true
+
+services:
+  plugin-linter:
+    image: buildkite/plugin-linter:latest # the only available tag
+    command: ["--id", "grapl-security/grapl-release"]
+    volumes:
+      - *read-only-plugin

--- a/hooks/BUILD
+++ b/hooks/BUILD
@@ -1,0 +1,5 @@
+shell_sources(
+    sources=[
+        "environment"
+    ]
+)

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "--- Adding the following binaries / scripts to the PATH"
+for bin in "${HOOKS_DIR}"/../bin/*; do
+    basename "${bin}"
+done
+
+export PATH="$PATH:$HOOKS_DIR/../bin"

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,0 +1,7 @@
+shell_sources()
+
+shunit2_tests(
+    name="tests",
+    # Currently using relative imports for tests, which aren't visible to Pants
+    dependencies=[":lib"],
+)

--- a/lib/record.sh
+++ b/lib/record.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Assuming our pipeline names are of the form of:
+#
+#     REPOSITORY_NAME/PIPELINE
+#
+# extracts the PIPELINE portion.
+#
+#     export BUILDKITE_PIPELINE_NAME=pipeline-infrastructure/merge
+#     pipeline_from_env
+#     # => merge
+#
+pipeline_from_env() {
+    echo "${BUILDKITE_PIPELINE_NAME##*/}"
+}
+
+# The lightweight Git tag we'll use to record which commit was the
+# last to successfully make it through the given pipeline. This will
+# be updated with every passing pipeline run. As such, it is
+# explicitly for internal use, and any dependence on the commit it
+# refers to remaining constant is WRONG.
+#
+#     tag_for_pipeline merge
+#     # => internal/last-successful-merge
+#
+tag_for_pipeline() {
+    local -r pipeline="${1}"
+    echo "internal/last-successful-${pipeline}"
+}
+
+# Update the tag for the given pipeline to the current commit and push
+# it to Github.
+tag_last_success() {
+    local -r pipeline="${1}"
+    local -r tag="$(tag_for_pipeline "${pipeline}")"
+
+    echo "--- :github: Re-tagging '${tag}'"
+    git tag "${tag}" --force
+    echo "--- :github: Pushing new value for '${tag}' tag"
+    git push origin "${tag}" --force --verbose
+}

--- a/lib/record_test.sh
+++ b/lib/record_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Simple git binary mock that just records its invocations
+git() {
+    echo "${FUNCNAME[0]} $*" >> "${ALL_COMMANDS}"
+}
+
+recorded_commands() {
+    if [ -f "${ALL_COMMANDS}" ]; then
+        cat "${ALL_COMMANDS}"
+    fi
+}
+
+oneTimeSetUp() {
+    export ALL_COMMANDS="${SHUNIT_TMPDIR}/all_commands"
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/record.sh"
+}
+
+test_pipeline_from_env() {
+    actual="$(BUILDKITE_PIPELINE_NAME=pipeline-infrastructure/merge pipeline_from_env)"
+
+    assertEquals "Failed to extract a pipeline key from BUILDKITE_PIPELINE_NAME" \
+        "merge" \
+        "${actual}"
+}
+
+test_tag_for_pipeline() {
+    assertEquals "internal/last-successful-merge" "$(tag_for_pipeline merge)"
+    assertEquals "internal/last-successful-provision" "$(tag_for_pipeline provision)"
+}
+
+test_tag_last_success() {
+
+    tag_last_success "merge"
+
+    expected=$(
+        cat << EOF
+git tag internal/last-successful-merge --force
+git push origin internal/last-successful-merge --force --verbose
+EOF
+    )
+
+    assertEquals "The expected git commands were not run" \
+        "${expected}" \
+        "$(recorded_commands)"
+}

--- a/pants
+++ b/pants
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# =============================== NOTE ===============================
+# This ./pants bootstrap script comes from the pantsbuild/setup
+# project. It is intended to be checked into your code repository so
+# that other developers have the same setup.
+#
+# Learn more here: https://www.pantsbuild.org/docs/installation
+# ====================================================================
+
+set -eou pipefail
+
+# NOTE: To use an unreleased version of Pants from the pantsbuild/pants main branch,
+#  locate the main branch SHA, set PANTS_SHA=<SHA> in the environment, and run this script as usual.
+#
+# E.g., PANTS_SHA=725fdaf504237190f6787dda3d72c39010a4c574 ./pants --version
+
+PYTHON_BIN_NAME="${PYTHON:-unspecified}"
+
+# Set this to specify a non-standard location for this script to read the Pants version from.
+# NB: This will *not* cause Pants itself to use this location as a config file.
+#     You can use PANTS_CONFIG_FILES or --pants-config-files to do so.
+PANTS_TOML=${PANTS_TOML:-pants.toml}
+
+PANTS_BIN_NAME="${PANTS_BIN_NAME:-$0}"
+
+PANTS_SETUP_CACHE="${PANTS_SETUP_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}/pants/setup}"
+# If given a relative path, we fix it to be absolute.
+if [[ "$PANTS_SETUP_CACHE" != /* ]]; then
+  PANTS_SETUP_CACHE="${PWD}/${PANTS_SETUP_CACHE}"
+fi
+
+PANTS_BOOTSTRAP="${PANTS_SETUP_CACHE}/bootstrap-$(uname -s)-$(uname -m)"
+
+_PEX_VERSION=2.1.42
+_PEX_URL="https://github.com/pantsbuild/pex/releases/download/v${_PEX_VERSION}/pex"
+_PEX_EXPECTED_SHA256="69d6b1b1009b00dd14a3a9f19b72cff818a713ca44b3186c9b12074b2a31e51f"
+
+VIRTUALENV_VERSION=20.4.7
+VIRTUALENV_REQUIREMENTS=$(
+cat << EOF
+virtualenv==${VIRTUALENV_VERSION} --hash sha256:2b0126166ea7c9c3661f5b8e06773d28f83322de7a3ff7d06f0aed18c9de6a76
+filelock==3.0.12 --hash sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836
+six==1.16.0 --hash sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+distlib==0.3.2 --hash sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c
+appdirs==1.4.4 --hash sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
+importlib-resources==5.1.4; python_version < "3.7" --hash sha256:e962bff7440364183203d179d7ae9ad90cb1f2b74dcb84300e88ecc42dca3351
+importlib-metadata==4.5.0; python_version < "3.8" --hash sha256:833b26fb89d5de469b24a390e9df088d4e52e4ba33b01dc5e0e4f41b81a16c00
+zipp==3.4.1; python_version < "3.10" --hash sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098
+typing-extensions==3.10.0.0; python_version < "3.8" --hash sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+EOF
+)
+
+COLOR_RED="\x1b[31m"
+COLOR_GREEN="\x1b[32m"
+COLOR_YELLOW="\x1b[33m"
+COLOR_RESET="\x1b[0m"
+
+function log() {
+  echo -e "$@" 1>&2
+}
+
+function die() {
+  (($# > 0)) && log "${COLOR_RED}$*${COLOR_RESET}"
+  exit 1
+}
+
+function green() {
+  (($# > 0)) && log "${COLOR_GREEN}$*${COLOR_RESET}"
+}
+
+function warn() {
+  (($# > 0)) && log "${COLOR_YELLOW}$*${COLOR_RESET}"
+}
+
+function tempdir {
+  mkdir -p "$1"
+  mktemp -d "$1"/pants.XXXXXX
+}
+
+function get_exe_path_or_die {
+  local exe="$1"
+  if ! command -v "${exe}"; then
+    die "Could not find ${exe}. Please ensure ${exe} is on your PATH."
+  fi
+}
+
+function get_pants_config_value {
+  local config_key="$1"
+  local optional_space="[[:space:]]*"
+  local prefix="^${config_key}${optional_space}=${optional_space}"
+  local raw_value
+  raw_value="$(sed -ne "/${prefix}/ s#${prefix}##p" "${PANTS_TOML}")"
+  echo "${raw_value}"  | tr -d \"\' && return 0
+  return 0
+}
+
+function get_python_major_minor_version {
+  local python_exe="$1"
+  "$python_exe" <<EOF
+import sys
+major_minor_version = ''.join(str(version_num) for version_num in sys.version_info[0:2])
+print(major_minor_version)
+EOF
+}
+
+# The high-level flow:
+#
+# 1.) Resolve the Pants version from config so that we know what interpreters we can use, what to name the venv,
+#     and what to install via pip.
+# 2.) Resolve the Python interpreter, first reading from the env var $PYTHON, then using a default based on the Pants
+#     version.
+# 3.) Check if the venv already exists via a naming convention, and create the venv if not found.
+# 4.) Execute Pants with the resolved Python interpreter and venv.
+#
+# After that, Pants itself will handle making sure any requested plugins
+# are installed and up to date.
+
+function determine_pants_version {
+  if [ -n "${PANTS_SHA:-}" ]; then
+    # get_version_for_sha will echo the version, thus "returning" it from this function.
+    get_version_for_sha "$PANTS_SHA"
+    return
+  fi
+
+  pants_version="$(get_pants_config_value 'pants_version')"
+  if [[ -z "${pants_version}" ]]; then
+    die "Please explicitly specify the \`pants_version\` in your \`pants.toml\` under the \`[GLOBAL]\` scope.
+See https://pypi.org/project/pantsbuild.pants/#history for all released versions
+and https://www.pantsbuild.org/docs/installation for more instructions."
+  fi
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  # 1.26 is the first version to support `pants.toml`, so we fail eagerly if using an outdated version.
+  if [[ "${pants_major_version}" -eq 1 && "${pants_minor_version}" -le 25 ]]; then
+    die "This version of the \`./pants\` script does not work with Pants <= 1.25.0 (and it also requires using \`pants.toml\`,
+rather than \`pants.ini\`). Instead, either upgrade your \`pants_version\` or use the version of the \`./pants\` script
+at https://raw.githubusercontent.com/Eric-Arellano/setup/0d445edef57cb89fd830db70810e38f050b0a268/pants."
+  fi
+  echo "${pants_version}"
+}
+
+function set_supported_python_versions {
+  local pants_version="$1"
+  local pants_major_version
+  local pants_minor_version
+  pants_major_version="$(echo "${pants_version}" | cut -d '.' -f1)"
+  pants_minor_version="$(echo "${pants_version}" | cut -d '.' -f2)"
+  if [[ "${pants_major_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 0 ]]; then
+    supported_python_versions_decimal=('3.6' '3.7' '3.8')
+    supported_python_versions_int=('36' '37' '38')
+    supported_message='3.6, 3.7, or 3.8'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -eq 1 ]]; then
+    supported_python_versions_decimal=('3.7' '3.8' '3.6')
+    supported_python_versions_int=('37' '38' '36')
+    supported_message='3.7, 3.8, or 3.6 (deprecated)'
+  elif [[ "${pants_major_version}" -eq 2 && "${pants_minor_version}" -lt 5 ]]; then
+    supported_python_versions_decimal=('3.8' '3.7')
+    supported_python_versions_int=('38' '37')
+    supported_message='3.7 or 3.8'
+  else
+    # We put 3.9 first because Apple Silicon only works properly with Python 3.9, even though it's possible to have
+    # older Pythons installed. This makes it more likely that Pants will work out-of-the-box.
+    supported_python_versions_decimal=('3.9' '3.8' '3.7')
+    supported_python_versions_int=('39' '38' '37')
+    supported_message='3.7, 3.8, or 3.9'
+  fi
+}
+
+function check_python_exe_compatible_version {
+  local python_exe="$1"
+  local major_minor_version
+  major_minor_version="$(get_python_major_minor_version "${python_exe}")"
+  for valid_version in "${supported_python_versions_int[@]}"; do
+    if [[ "${major_minor_version}" == "${valid_version}" ]]; then
+      echo "${python_exe}" && return 0
+    fi
+  done
+}
+
+function determine_default_python_exe {
+  for version in "${supported_python_versions_decimal[@]}" "3" ""; do
+    local interpreter_path
+    interpreter_path="$(command -v "python${version}")"
+    if [[ -z "${interpreter_path}" ]]; then
+      continue
+    fi
+    # Check if the Python version is installed via Pyenv but not activated.
+    if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
+      continue
+    fi
+    if [[ -n "$(check_python_exe_compatible_version "${interpreter_path}")" ]]; then
+      echo "${interpreter_path}" && return 0
+    fi
+  done
+}
+
+function determine_python_exe {
+  local pants_version="$1"
+  set_supported_python_versions "${pants_version}"
+  local requirement_str="For \`pants_version = \"${pants_version}\"\`, Pants requires Python ${supported_message} to run."
+
+  local python_exe
+  if [[ "${PYTHON_BIN_NAME}" != 'unspecified' ]]; then
+    python_exe="$(get_exe_path_or_die "${PYTHON_BIN_NAME}")" || exit 1
+    if [[ -z "$(check_python_exe_compatible_version "${python_exe}")" ]]; then
+      die "Invalid Python interpreter version for ${python_exe}. ${requirement_str}"
+    fi
+  else
+    python_exe="$(determine_default_python_exe)"
+    if [[ -z "${python_exe}" ]]; then
+      die "No valid Python interpreter found. ${requirement_str} Please check that a valid interpreter is installed and on your \$PATH."
+    fi
+  fi
+  echo "${python_exe}"
+}
+
+function compute_sha256 {
+  local python="$1"
+  local path="$2"
+
+  "$python" <<EOF
+import hashlib
+
+hasher = hashlib.sha256()
+with open('${path}', 'rb') as fp:
+    buf = fp.read()
+    hasher.update(buf)
+print(hasher.hexdigest())
+EOF
+}
+
+# TODO(John Sirois): GC race loser tmp dirs leftover from bootstrap_XXX
+# functions.  Any tmp dir w/o a symlink pointing to it can go.
+
+function bootstrap_pex {
+  local python="$1"
+  local bootstrapped="${PANTS_BOOTSTRAP}/pex-${_PEX_VERSION}/pex"
+  if [[ ! -f "${bootstrapped}" ]]; then
+    (
+      green "Downloading the Pex PEX."
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      curl -LO "${_PEX_URL}"
+      fingerprint="$(compute_sha256 "${python}" "pex")"
+      if [[ "${_PEX_EXPECTED_SHA256}" != "${fingerprint}" ]]; then
+        die "SHA256 of ${_PEX_URL} is not as expected. Aborting."
+      fi
+      green "SHA256 fingerprint of ${_PEX_URL} verified."
+      mkdir -p "$(dirname "${bootstrapped}")"
+      mv -f "${staging_dir}/pex" "${bootstrapped}"
+      rmdir "${staging_dir}"
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+function scrub_PEX_env_vars {
+  # Ensure the virtualenv PEX runs as shrink-wrapped.
+  # See: https://github.com/pantsbuild/setup/issues/105
+  if [[ -n "${!PEX_@}" ]]; then
+    warn "Scrubbing ${!PEX_@}"
+    unset "${!PEX_@}"
+  fi
+}
+
+function bootstrap_virtualenv {
+  local python="$1"
+  local bootstrapped="${PANTS_BOOTSTRAP}/virtualenv-${VIRTUALENV_VERSION}/virtualenv.pex"
+  if [[ ! -f "${bootstrapped}" ]]; then
+    (
+      green "Creating the virtualenv PEX."
+      pex_path="$(bootstrap_pex "${python}")" || exit 1
+      mkdir -p "${PANTS_BOOTSTRAP}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      cd "${staging_dir}"
+      echo "${VIRTUALENV_REQUIREMENTS}" > requirements.txt
+      (
+        scrub_PEX_env_vars
+        "${python}" "${pex_path}" -r requirements.txt -c virtualenv -o virtualenv.pex
+      )
+      mkdir -p "$(dirname "${bootstrapped}")"
+      mv -f "${staging_dir}/virtualenv.pex" "${bootstrapped}"
+      rm -rf "${staging_dir}"
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+function find_links_url {
+  local pants_version="$1"
+  local pants_sha="$2"
+  echo -n "https://binaries.pantsbuild.org/wheels/pantsbuild.pants/${pants_sha}/${pants_version/+/%2B}/index.html"
+}
+
+function get_version_for_sha {
+  local sha="$1"
+
+  # Retrieve the Pants version associated with this commit.
+  local pants_version
+  pants_version="$(curl --fail -sL "https://raw.githubusercontent.com/pantsbuild/pants/${sha}/src/python/pants/VERSION")"
+
+  # Construct the version as the release version from src/python/pants/VERSION, plus the string `+gitXXXXXXXX`,
+  # where the XXXXXXXX is the first 8 characters of the SHA.
+  echo "${pants_version}+git${sha:0:8}"
+}
+
+function bootstrap_pants {
+  local pants_version="$1"
+  local python="$2"
+  local pants_sha="${3:-}"
+
+  local pants_requirement="pantsbuild.pants==${pants_version}"
+  local maybe_find_links
+  if [[ -z "${pants_sha}" ]]; then
+    maybe_find_links=""
+  else
+    maybe_find_links="--find-links=$(find_links_url "${pants_version}" "${pants_sha}")"
+   fi
+  local python_major_minor_version
+  python_major_minor_version="$(get_python_major_minor_version "${python}")"
+  local target_folder_name="${pants_version}_py${python_major_minor_version}"
+  local bootstrapped="${PANTS_BOOTSTRAP}/${target_folder_name}"
+
+  if [[ ! -d "${bootstrapped}" ]]; then
+    (
+      green "Bootstrapping Pants using ${python}"
+      local staging_dir
+      staging_dir=$(tempdir "${PANTS_BOOTSTRAP}")
+      local virtualenv_path
+      virtualenv_path="$(bootstrap_virtualenv "${python}")" || exit 1
+      green "Installing ${pants_requirement} into a virtual environment at ${bootstrapped}"
+      (
+        scrub_PEX_env_vars
+        # shellcheck disable=SC2086
+        "${python}" "${virtualenv_path}" --no-download "${staging_dir}/install" && \
+        "${staging_dir}/install/bin/pip" install -U pip && \
+        "${staging_dir}/install/bin/pip" install ${maybe_find_links} --progress-bar off "${pants_requirement}"
+      ) && \
+      ln -s "${staging_dir}/install" "${staging_dir}/${target_folder_name}" && \
+      mv "${staging_dir}/${target_folder_name}" "${bootstrapped}" && \
+      green "New virtual environment successfully created at ${bootstrapped}."
+    ) 1>&2 || exit 1
+  fi
+  echo "${bootstrapped}"
+}
+
+# Ensure we operate from the context of the ./pants buildroot.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+pants_version="$(determine_pants_version)"
+python="$(determine_python_exe "${pants_version}")"
+pants_dir="$(bootstrap_pants "${pants_version}" "${python}" "${PANTS_SHA:-}")" || exit 1
+
+pants_python="${pants_dir}/bin/python"
+pants_binary="${pants_dir}/bin/pants"
+pants_extra_args=""
+if [[ -n "${PANTS_SHA:-}" ]]; then
+  pants_extra_args="${pants_extra_args} --python-repos-repos=$(find_links_url "$pants_version" "$PANTS_SHA")"
+fi
+
+# shellcheck disable=SC2086
+exec "${pants_python}" "${pants_binary}" ${pants_extra_args} \
+  --pants-bin-name="${PANTS_BIN_NAME}" --pants-version=${pants_version} "$@"

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,0 +1,16 @@
+[GLOBAL]
+dynamic_ui = false
+colors = true
+
+# Since multiple jobs could run on the same Buildkite worker node, we
+# need to make sure the cache directories are isolated.
+local_store_dir = ".cache/pants/lmdb_store"
+named_caches_dir = ".cache/pants/named_caches"
+
+pants_ignore = [
+  ".cache/pants/named_caches",
+  ".cache/pants/lmdb_store",
+]
+
+[auth]
+from_env_var = "TOOLCHAIN_AUTH_TOKEN"

--- a/pants.toml
+++ b/pants.toml
@@ -1,0 +1,52 @@
+[GLOBAL]
+pants_version = "2.8.0"
+backend_packages = [
+    "pants.backend.shell",
+    "pants.backend.shell.lint.shellcheck",
+    "pants.backend.shell.lint.shfmt",
+]
+
+pants_ignore = [
+    "!.buildkite/"
+]
+
+plugins = [
+  "toolchain.pants.plugin==0.14.0"
+]
+
+remote_cache_read = true
+remote_cache_write = true
+remote_store_address = "grpcs://cache.toolchain.com:443"
+remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
+
+[toolchain-setup]
+repo = "grapl-release-buildkite-plugin"
+
+[buildsense]
+enable = true
+
+# See https://www.pantsbuild.org/docs/anonymous-telemetry
+[anonymous-telemetry]
+enabled = true
+# Randomly generated with `uuidgen --random`
+repo_id = "c18b8b69-2a9b-4bf5-9084-2fd6c8852c8b"
+
+[shfmt]
+# Indent with 4 spaces
+# Indent switch cases
+# Redirect operators are followed by a space
+args = ["-i 4", "-ci", "-sr"]
+
+[test]
+output = "all"
+
+[shellcheck]
+# Currently, Pants only knows about v0.7.1, but v0.7.2 has some nice
+# relative sourcing features we'd like to take advantage of (namely,
+# `script-path=SOURCEDIR`). Once Pants knows about v0.7.2 natively, we
+# can remove these configuration values.
+version = "v0.7.2"
+known_versions = [
+  "v0.7.2|macos_x86_64|969bd7ef668e8167cfbba569fb9f4a0b2fc1c4021f87032b6a0b0e525fb77369|3988092",
+  "v0.7.2|linux_x86_64|70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188|1382204"
+]

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,10 @@
+---
+name: grapl-release
+description: Grapl release / tagging logic
+author: https://github.com/grapl-security
+requirements:
+  - bash
+  - git
+configuration:
+  properties: {}
+  additionalProperties: false


### PR DESCRIPTION
This plugin exposes some more of the logic we were sharing via
https://github.com/grapl-security/buildkite-common as a formal
Buildkite plugin.

In particular, this commit introduces the logic for updating our
internal tracking tags, as well as the diff script we use (which
leverages those same tags).

For now, this is a "library" plugin, which basically allows us to
inject scripts and binaries into the `PATH`, which commands can then
use as they see fit.

Longer-term, we'll add more release-centric logic to this plugin.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>