### PR TITLE
Add "real run" awareness to tag push operation

### DIFF
--- a/lib/record.sh
+++ b/lib/record.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
+
 # Assuming our pipeline names are of the form of:
 #
 #     REPOSITORY_NAME/PIPELINE
@@ -36,6 +39,11 @@ tag_last_success() {
 
     echo "--- :github: Re-tagging '${tag}'"
     git tag "${tag}" --force
-    echo "--- :github: Pushing new value for '${tag}' tag"
-    git push origin "${tag}" --force --verbose
+
+    if is_real_run; then
+        echo "--- :github: Pushing new value for '${tag}' tag"
+        git push origin "${tag}" --force --verbose
+    else
+        echo -e "--- :no_good: Would have pushed '${tag}' tag to Github"
+    fi
 }

--- a/lib/record_test.sh
+++ b/lib/record_test.sh
@@ -17,6 +17,12 @@ oneTimeSetUp() {
     source "$(dirname "${BASH_SOURCE[0]}")/record.sh"
 }
 
+setUp() {
+    # Ensure any recorded commands from the last test are removed so
+    # we start with a clean slate.
+    rm -f "${ALL_COMMANDS}"
+}
+
 test_pipeline_from_env() {
     actual="$(BUILDKITE_PIPELINE_NAME=pipeline-infrastructure/merge pipeline_from_env)"
 
@@ -32,12 +38,43 @@ test_tag_for_pipeline() {
 
 test_tag_last_success() {
 
-    tag_last_success "merge"
+    BUILDKITE_SOURCE=webhook tag_last_success "merge"
 
     expected=$(
         cat << EOF
 git tag internal/last-successful-merge --force
 git push origin internal/last-successful-merge --force --verbose
+EOF
+    )
+
+    assertEquals "The expected git commands were not run" \
+        "${expected}" \
+        "$(recorded_commands)"
+}
+
+test_tag_last_success_with_fake_build() {
+
+    BUILDKITE_SOURCE=ui tag_last_success "provision"
+
+    expected=$(
+        cat << EOF
+git tag internal/last-successful-provision --force
+EOF
+    )
+
+    assertEquals "The expected git commands were not run" \
+        "${expected}" \
+        "$(recorded_commands)"
+}
+
+test_tag_last_success_with_fake_build_and_escape_hatch() {
+
+    BREAK_GLASS_IN_CASE_OF_EMERGENCY=1 BUILDKITE_SOURCE=ui tag_last_success "provision"
+
+    expected=$(
+        cat << EOF
+git tag internal/last-successful-provision --force
+git push origin internal/last-successful-provision --force --verbose
 EOF
     )
 

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Determines whether this pipeline run is "real" or if it was an
+# ad-hoc one triggered by a person for testing. If the latter, there
+# are some actions that we don't want to perform (such as pushing a
+# new merge commit to an `rc` branch, performing a release, etc.).
+#
+# In the rare case that a human *does* need to legitimately run a
+# pipeline *as though it were a real run*, then the
+# `BREAK_GLASS_IN_CASE_OF_EMERGENCY` environment variable should be
+# set.
+#
+# Hinges on the value of `BUILDKITE_SOURCE`; see
+# https://buildkite.com/docs/pipelines/environment-variables#bk-env-vars-buildkite-source
+# for details.
+is_real_run() {
+    case "${BUILDKITE_SOURCE}" in
+        webhook | api | trigger_job | schedule)
+            true
+            ;;
+        ui)
+            if [ -n "${BREAK_GLASS_IN_CASE_OF_EMERGENCY:-}" ]; then
+                true
+            else
+                false
+            fi
+            ;;
+        *)
+            echo "--- :exclamation_mark: Unrecognized BUILDKITE_SOURCE: ${BUILDKITE_SOURCE}; cowardly refusing to consider this run \"real\""
+            false
+            ;;
+    esac
+}

--- a/lib/util_test.sh
+++ b/lib/util_test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+oneTimeSetUp() {
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
+}
+
+test_is_real_run() {
+    unset BREAK_GLASS_IN_CASE_OF_EMERGENCY
+    local BUILDKITE_SOURCE
+
+    BUILDKITE_SOURCE=webhook
+    assertTrue "webhook-initiated runs are considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=api
+    assertTrue "api-initiated runs are considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=trigger_job
+    assertTrue "trigger-initiated runs are considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=schedule
+    assertTrue "scheduled runs are considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=ui
+    assertFalse "UI-initiated runs are *not* considered \"real\"" is_real_run
+
+    BUILDKITE_SOURCE=not_a_valid_buildkite_source
+    assertFalse "A run with an unrecognized BUILDKITE_SOURCE is never considered \"real\"" is_real_run
+}
+
+test_is_real_run_with_override() {
+    local BREAK_GLASS_IN_CASE_OF_EMERGENCY=1
+    local BUILDKITE_SOURCE
+
+    BUILDKITE_SOURCE=webhook
+    assertTrue "webhook-initiated runs are considered \"real\", regardless of override" is_real_run
+
+    BUILDKITE_SOURCE=api
+    assertTrue "api-initiated runs are considered \"real\", regardless of override" is_real_run
+
+    BUILDKITE_SOURCE=trigger_job
+    assertTrue "trigger-initiated runs are considered \"real\", regardless of override" is_real_run
+
+    BUILDKITE_SOURCE=schedule
+    assertTrue "scheduled runs are considered \"real\", regardless of override" is_real_run
+
+    BUILDKITE_SOURCE=ui
+    assertTrue "UI-initiated runs are *only* considered \"real\" in the presence of an override" is_real_run
+
+    BUILDKITE_SOURCE=not_a_valid_buildkite_source
+    assertFalse "A run with an unrecognized BUILDKITE_SOURCE is never considered \"real\"" is_real_run
+}


### PR DESCRIPTION
This adds the `is_real_run` logic we use in our `grapl-rc` Buildkite
plugin to this plugin. If we're doing a "test run" of any pipeline
that uses this plugin, we don't want to inadvertently push tags to
Github; that should only happen for "real" pipeline runs (here, "real"
is currently defined as any build not triggered via the UI).

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
