### PR TITLE
Add logging library to take advantage of `log_and_run` function

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Various logging functions and helpers to make logging nice.
+
+# ANSI Formatting Codes
+########################################################################
+# Because who wants to remember all those fiddly details?
+
+# CSI = "Control Sequence Introducer"
+CSI="\e["
+END=m
+
+NORMAL=0
+BOLD=1
+
+WHITE=37
+
+RESET="${CSI}${NORMAL}${END}"
+
+function _bold_color() {
+    color="${1}"
+    shift
+    echo "${CSI}${BOLD};${color}${END}${*}${RESET}"
+}
+
+function bright_white() {
+    _bold_color "${WHITE}" "${@}"
+}
+
+# Logging
+########################################################################
+# NOTE: All logs get sent to standard error
+
+function log() {
+    echo -e "${@}" >&2
+}
+
+# Handy for logging the exact command to be run, and then running it
+function log_and_run() {
+    log ❯❯ "$(bright_white "$(printf "%q " "${@}")")"
+    "$@"
+}
+
+raise_error() {
+    log "--- :rotating_light:" "${@}"
+    # Yes, these numbers are correct :/
+    if [ -z "${BASH_SOURCE[2]:-}" ]; then
+        # If we're calling raise_error from a script directly, we'll
+        # have a shorter call stack.
+        log "Failed in ${FUNCNAME[1]}() at [${BASH_SOURCE[1]}:${BASH_LINENO[0]}]"
+    else
+        log "Failed in ${FUNCNAME[1]}() at [${BASH_SOURCE[1]}:${BASH_LINENO[0]}], called from [${BASH_SOURCE[2]}:${BASH_LINENO[1]}]"
+    fi
+    exit 1
+}

--- a/lib/record.sh
+++ b/lib/record.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 # shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/log.sh"
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
 
 # Assuming our pipeline names are of the form of:
@@ -38,11 +40,11 @@ tag_last_success() {
     local -r tag="$(tag_for_pipeline "${pipeline}")"
 
     echo "--- :github: Re-tagging '${tag}'"
-    git tag "${tag}" --force
+    log_and_run git tag "${tag}" --force
 
     if is_real_run; then
         echo "--- :github: Pushing new value for '${tag}' tag"
-        git push origin "${tag}" --force --verbose
+        log_and_run git push origin "${tag}" --force --verbose
     else
         echo -e "--- :no_good: Would have pushed '${tag}' tag to Github"
     fi


### PR DESCRIPTION
Troubleshooting is always easier if you can just see the concrete
commands that are run from the Buildkite log, rather than digging
through the plugin source code.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
