### PR TITLE
Pin `buildkite/plugin-linter` image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 COMPOSE_USER=$(shell id -u):$(shell id -g)
-
-RUN_CHECK := docker-compose run --rm --user=${COMPOSE_USER}
+RUN_CHECK := docker compose run --rm --user=$(COMPOSE_USER)
 
 .DEFAULT_GOAL=all
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-common-variables:
   read-only-workdir: &read-only-workdir
     type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ x-common-variables:
 
 services:
   plugin-linter:
-    image: buildkite/plugin-linter:latest # the only available tag
+    image: buildkite/plugin-linter@sha256:833b1ce8326b038c748c8f04d317045205e115b1732a6842ec4a957f550fe357
     command: ["--id", "grapl-security/grapl-release"]
     volumes:
       - *read-only-plugin


### PR DESCRIPTION
I noticed that our use of the `buildkite/plugin-linter` image was also pinned to `latest`. There are no formal release of this image (yet :crossed_fingers:), so I've pinned it to a concrete SHA to be safe.

While making this fix, I also took the liberty of shifting our Docker Compose usage explicitly to v2, as we have been doing across all our projects lately.